### PR TITLE
Add custom parameters

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -3,7 +3,7 @@
 echo "Installing Cake bootstrapper"
 curl -Lsfo build.sh https://cakebuild.net/download/bootstrapper/osx
 
-echo "Checking custom nuget sources"
+echo "Checking custom NuGet sources"
 nuget="/Library/Frameworks/Mono.framework/Versions/Current/bin/nuget"
 
 if [ ! -z "${nuget_source_name}" ] && [ ! -z "${nuget_source_path_or_url}" ] && [ -z "${nuget_source_username}" ] && [ -z "${nuget_source_password}" ] ; then
@@ -16,6 +16,33 @@ if [ ! -z "${nuget_source_name}" ] && [ ! -z "${nuget_source_path_or_url}" ] && 
     "${nuget}" sources add -Name "${nuget_source_name}" -Source "${nuget_source_path_or_url}" -Verbosity "detailed"
 fi
 
-echo "Executing Cake Script"
+script_args=""
+
+if [ ! -z $script ] ; then
+    echo "Adding script parameter"
+    script_args="${script_args} -s \"${script}\""
+fi
+
+if [ ! -z $verbosity ] ; then
+    echo "Adding verbosity parameter"
+    script_args="${script_args} --verbosity=${verbosity}"
+fi
+
+if [ ! -z $configuration ] ; then
+    echo "Adding configuration parameter"
+    script_args="${script_args} --configuration=${configuration}"
+fi
+
+if [ ! -z $target ] ; then
+    echo "Adding target parameter"
+    script_args="${script_args} --target=${target}"
+fi
+
+if [ ! -z $custom_args ] ; then
+    echo "Adding target parameter"
+    script_args="${script_args} ${custom_args}"
+fi
+
+echo "Executing Cake Script with arguments ${script_args}"
 chmod +x build.sh
-./build.sh -s "${script}" --verbosity="${verbosity}" --configuration="${configuration}" --target="${target}"
+./build.sh "$script_args"

--- a/step.yml
+++ b/step.yml
@@ -17,40 +17,47 @@ is_requires_admin_user: false
 is_always_run: false
 is_skippable: false
 inputs:
-  - script: build.cake
+  - script:
     opts:
       title: "Script"
       description: |
         Name of the script to execute. Default is build.cake
       is_expand: true
-      is_required: true
-  - target: Default
+      is_required: false
+  - target:
     opts:
       title: "Target"
       description: |
         Target name to execute. Default is Default
       is_expand: true
-      is_required: true
-  - configuration: Release
+      is_required: false
+  - configuration:
     opts:
       title: "Configuration"
       description: |
         Configuration to build. Default is Release.
       is_expand: true
-      is_required: true
-  - verbosity: normal
+      is_required: false
+  - verbosity:
     opts:
       title: "Verbosity"
       description: |
         Specifies the amount of information to be displayed (quiet, minimal, normal, verbose, diagnostic).
       is_expand: true
-      is_required: true
+      is_required: false
       value_options:
       - quiet
       - minimal
       - normal
       - verbose
       - diagnostic
+  - custom_args:
+    opts:
+      title: "Custom arguments"
+      description: |
+        Custom arguments to add to the build script
+      is_expand: true
+      is_required: false
   - nuget_source_name:
     opts:
       title: "NuGet private source name"

--- a/step.yml
+++ b/step.yml
@@ -23,28 +23,28 @@ inputs:
       description: |
         Name of the script to execute. Default is build.cake
       is_expand: true
-      is_required: false
+      is_required: true
   - target:
     opts:
       title: "Target"
       description: |
         Target name to execute. Default is Default
       is_expand: true
-      is_required: false
+      is_required: true
   - configuration:
     opts:
       title: "Configuration"
       description: |
         Configuration to build. Default is Release.
       is_expand: true
-      is_required: false
+      is_required: true
   - verbosity:
     opts:
       title: "Verbosity"
       description: |
         Specifies the amount of information to be displayed (quiet, minimal, normal, verbose, diagnostic).
       is_expand: true
-      is_required: false
+      is_required: true
       value_options:
       - quiet
       - minimal


### PR DESCRIPTION
The current bootstrapper doesn't have the hardcoded parameters anymore. It just passes everything except for the script parameter on to the cake build file itself. So this step pushes you to use the predefined parameters target, verbosity etc. while these might not even exist in your script.