### PR TITLE
custom_args - is_expand: true -> false

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -56,7 +56,7 @@ inputs:
       title: "Custom arguments"
       description: |
         Custom arguments to add to the build script
-      is_expand: true
+      is_expand: false
       is_required: false
   - nuget_source_name:
     opts:


### PR DESCRIPTION
Not sure which would be the better default

If it's `true` then you can't really include `$` in this input's value. To be more precise in that case `$X` will be expanded by the CLI itself, before even starting the step. This should be fine for things like `$HOME` as that should be the same value before starting the step and in the step, but might be an issue if it should be part of the value, e.g. in a password like `P4s$word` where the CLI will expand this to most likely `P4s` (because `$word` env var is empty / not defined).

If `is_expand` is `false` then it will be expanded by Bash in your `script.sh`, which is most likely what you want to do.

Of course up to you to decide which one's the better fit for this input, just wanted to highlight this and start a discussion in case you have any questions :)