### PR TITLE
Fixed issue with argument parsing

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -45,4 +45,4 @@ fi
 
 echo "Executing Cake Script with arguments ${script_args}"
 chmod +x build.sh
-./build.sh "$script_args"
+./build.sh $script_args


### PR DESCRIPTION
Due to the `""` the build script received all the parameters as a single script argument instead of separate arguments. Removing the `""` fixes this and resolves the _Multiple scripts_ issue.